### PR TITLE
Replace the previous autopilot with a three-loop autopilot

### DIFF
--- a/pysimenv/missile/__init__.py
+++ b/pysimenv/missile/__init__.py
@@ -5,7 +5,7 @@ from pysimenv.missile.model import PlanarKin, PitchDyn, PlanarVehicle, PlanarMis
     PlanarMissileWithPitch, PlanarMovingTarget
 from pysimenv.missile.engagement import Engagement2dim
 from pysimenv.missile.guidance import PurePNG2dim, IACBPNG
-from pysimenv.missile.control import PitchAP
+from pysimenv.missile.control import ThreeLoopAP
 from pysimenv.missile.util import RelKin2dim, CloseDistCond, miss_distance
 
 __all__ = ['missile']

--- a/pysimenv/missile/documents/Three_loop_autopilot.md
+++ b/pysimenv/missile/documents/Three_loop_autopilot.md
@@ -1,0 +1,53 @@
+## Three-loop autopilot
+
+##### 2022/10/17
+
+#### Pitch dynamic model
+
+Assume that a missile configuration is symmetric and a roll motion is stabilized. The longitudinal dynamics is given by
+$$
+\begin{align}
+\dot{\alpha} &= q + \frac{a_{z}}{V} \\
+\dot{q} &= \frac{QSd}{I_{yy}}\left( C_{m_{0}} + C_{m_{q}}\left(\frac{d}{2V} \right)q + C_{m_{\delta}}\delta \right) \\
+\end{align}
+$$
+where
+$$
+a_{z} = \frac{QS}{m}\left(C_{z_{0}} + C_{z_{\delta}}\delta \right)
+$$
+The linearized aerodynamic model is given by
+$$
+\begin{align}
+\dot{\alpha} &= q + \frac{a_{z}}{V} = q - \frac{a_{L}}{V} \\
+\dot{q} &= \frac{QSd}{I_{yy}}\left(C_{m_{0, \alpha}}\alpha + C_{m_{q}}\left( \frac{d}{2V} \right)q + C_{m_{\delta}}\delta \right) = M_{\alpha}\alpha + M_{q}q + M_{\delta}\delta \\
+a_{L} &= -\frac{QS}{m}(C_{z_{0, \alpha}}\alpha + C_{z_{\delta}}\delta) = L_{\alpha}\alpha + L_{\delta}\delta
+\end{align}
+$$
+
+
+#### Three-loop autopilot
+
+The dynamic of the lift acceleration can be approximated as
+$$
+\begin{align}
+\dot{a_{L}} &= L_{\alpha}\dot{\alpha} + L_{\delta}\dot{\delta} \approx L_{\alpha}\dot{\alpha} \\
+&= L_{\alpha}\left(q - \frac{a_{L}}{V} \right)
+\end{align}
+$$
+since generally $\vert  L_{\delta} \vert \ll \vert L_{\alpha} \vert$ holds. For the acceleration loop (outer loop), the desired pitch angle is computed as
+$$
+\begin{align}
+q_{c} &= \frac{1}{L_{\alpha}}\frac{1}{\tau_{d}}(a_{L_{c}} - a_{L}) + \frac{1}{V}a_{L} \\
+&= \left( \frac{1}{L_{\alpha}}\frac{1}{\tau_{d}} - \frac{1}{V} \right) \left( \frac{V}{V - L_{\alpha}\tau_{d}}a_{L_{c}} - a_{L} \right) \\
+&= K_{A}(K_{DC}a_{L_{c}} - a_{L})
+\end{align}
+$$
+For the pitch rate loop (inner loop), the desired fin command is computed as
+$$
+\begin{align}
+\delta_{c} &= \frac{1}{M_{\delta}}\left( \omega_{d}^{2}\int (q_{c} - q)dt - 2\zeta_{d}\omega_{d}q - M_{q}q \right) \\
+&= \frac{1}{M_{q}} \left( \omega_{d}^{2}\int (q_{c} - q)dt - (2\zeta_{d}\omega_{d} + M_{q})q \right) \\
+&= \frac{2\zeta_{d}\omega_{d} + M_{q}}{M_{\delta}}\left( \frac{\omega_{d}^{2}}{2\zeta_{d}\omega_{d} + M_{q}}\int (q_{c} - q)dt - q \right) \\
+&= K_{R}\left(\omega_{i}\int (q_{c} - q)dt - q \right)
+\end{align}
+$$

--- a/pysimenv/missile/model.py
+++ b/pysimenv/missile/model.py
@@ -261,8 +261,8 @@ class PlanarMissileWithPitch(PlanarMissile):
                  pitch_dyn: PitchDyn, pitch_ap: SimObject, tau, name="missile", **kwargs):
         super(PlanarMissileWithPitch, self).__init__(p_0, V_0, gamma_0, name=name, **kwargs)
         self.pitch_dyn = pitch_dyn
-        self.act_dyn = FirstOrderLinSys(x_0=np.array([0.]), tau=tau)
         self.pitch_ap = pitch_ap
+        self.act_dyn = FirstOrderLinSys(x_0=np.array([0.]), tau=tau)
         self._add_sim_objs([self.pitch_dyn, self.act_dyn, self.pitch_ap])
 
     # override
@@ -271,11 +271,11 @@ class PlanarMissileWithPitch(PlanarMissile):
         return sigma
 
     def _forward(self, a_M_cmd: float):
-        a_L_c = a_M_cmd  # approximation
         delta = self.act_dyn.output
+        q = self.pitch_dyn.output[2]
         a_L = self.pitch_dyn.lift_accel(delta)
-        x_p = self.pitch_dyn.output
-        delta_c = self.pitch_ap.forward(a_L=a_L, q=x_p[2], delta=delta, a_L_c=a_L_c)
+        a_L_c = a_M_cmd  # approximation
+        delta_c = self.pitch_ap.forward(q=q, a_L=a_L, a_L_c=a_L_c)
 
         self.act_dyn.forward(u=np.array([delta_c]))
         self.pitch_dyn.forward(delta=delta)

--- a/pysimenv/missile/test_missile_with_pitch.py
+++ b/pysimenv/missile/test_missile_with_pitch.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pysimenv.core.simulator import Simulator
 from pysimenv.missile.model import PitchDyn, PlanarMissileWithPitch, PlanarMovingTarget
-from pysimenv.missile.control import PitchAP
+from pysimenv.missile.control import ThreeLoopAP
 from pysimenv.missile.guidance import PurePNG2dim
 from pysimenv.missile.engagement import Engagement2dim
 
@@ -10,7 +10,7 @@ def main():
     aero_params = dict(L_alp=1270., L_delta=80., M_alp=-74., M_q=-5., M_delta=160.)
 
     pitch_dyn = PitchDyn(x_0=np.zeros(3), V=300., **aero_params)
-    pitch_ap = PitchAP(V=300., **aero_params, tau=0.02)
+    pitch_ap = ThreeLoopAP(V=300., **aero_params, tau_d=0.15, omega_d=30., zeta_d=1.)
     missile = PlanarMissileWithPitch(p_0=[-5000., 0.], V_0=300., gamma_0=np.deg2rad(30.),
                                      pitch_dyn=pitch_dyn, pitch_ap=pitch_ap, tau=0.02, name="missile")
     target = PlanarMovingTarget(p_0=[0., 0.], V_0=20., gamma_0=0., name="target")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysimenv",
-    version="0.0.14",
+    version="0.0.15",
     author="Sangmin Lee",
     author_email="everlastingminii@gmail.com",
     description="A framework for performing numerical simulation of dynamic systems",


### PR DESCRIPTION
* The previous `PitchAP` class has been replaced with `ThreeLoopAP` class. The control gains are determined by `tau_d`, `omega_d`, `zeta_d` where `tau_d` is the desired time constant of the acceleration (outer) loop, `omega_d` is the desired natural frequency of the rate (inner) loop and `zeta_d` is the desired damping ratio of the rate loop. Refer to the document for the details.