### PR TITLE
Add a discrete system (#54)

### DIFF
--- a/pysimenv/test/test_dt_sys.py
+++ b/pysimenv/test/test_dt_sys.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from pysimenv.core.base import DiscreteTimeDynSystem
+from pysimenv.core.simulator import Simulator
+
+
+class ConstAccel(DiscreteTimeDynSystem):
+    def __init__(self, p_0: np.ndarray, v_0: np.ndarray, **kwargs):
+        super(ConstAccel, self).__init__(
+            initial_states={'p': p_0, 'v': v_0}, **kwargs
+        )
+
+    # implement
+    def _update(self, p, v, a):
+        T = self.interval
+
+        p_next = p + T*v + 0.5*(T**2)*a
+        v_next = v + T*a
+        return {'p': p_next, 'v': v_next}
+
+
+def main():
+    p_0 = np.array([0., 0.])
+    v_0 = np.array([10., 0.])
+
+    model = ConstAccel(p_0, v_0, interval=0.5, name="model")
+    simulator = Simulator(model)
+    simulator.propagate(0.01, 10., save_history=True, a=np.array([-2., 1.]))
+    model.default_plot(show=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysimenv",
-    version="0.0.19",
+    version="0.0.20",
     author="Sangmin Lee",
     author_email="everlastingminii@gmail.com",
     description="A framework for performing numerical simulation of dynamic systems",


### PR DESCRIPTION
* `DiscreteTimeObject` and `DiscreteTimeDynSystem` classes have been added.
* To use `DiscreteTimeObject` class, a user must implement `_forward` method.
* To use `DiscreteTimeDynSystem` class, a user must implement `_update` method.